### PR TITLE
Enable storage config for react-native

### DIFF
--- a/packages/aws-amplify-react-native/dist/Auth/Auth.js
+++ b/packages/aws-amplify-react-native/dist/Auth/Auth.js
@@ -75,11 +75,12 @@ class AuthClass {
 
         this._config = Object.assign({}, this._config, conf);
 
-        const { userPoolId, userPoolWebClientId } = this._config;
+        const { userPoolId, userPoolWebClientId, storage } = this._config;
         if (userPoolId) {
             this.userPool = new CognitoUserPool({
                 UserPoolId: userPoolId,
-                ClientId: userPoolWebClientId
+                ClientId: userPoolWebClientId,
+                Storage: storage
             });
         }
 
@@ -201,14 +202,16 @@ class AuthClass {
             return Promise.reject('Password cannot be empty');
         }
 
-        const { userPoolId, userPoolWebClientId } = this._config;
+        const { userPoolId, userPoolWebClientId, storage } = this._config;
         const pool = new CognitoUserPool({
             UserPoolId: userPoolId,
-            ClientId: userPoolWebClientId
+            ClientId: userPoolWebClientId,
+            Storage: storage
         });
         const user = new CognitoUser({
             Username: username,
-            Pool: this.userPool
+            Pool: this.userPool,
+            Storage: storage
         });
         const authDetails = new AuthenticationDetails({
             Username: username,

--- a/packages/aws-amplify-react-native/src/Auth/Auth.js
+++ b/packages/aws-amplify-react-native/src/Auth/Auth.js
@@ -85,11 +85,12 @@ class AuthClass {
             conf
         );
 
-        const { userPoolId, userPoolWebClientId } = this._config;
+        const { userPoolId, userPoolWebClientId, storage } = this._config;
         if (userPoolId) {
             this.userPool = new CognitoUserPool({
                 UserPoolId: userPoolId,
-                ClientId: userPoolWebClientId
+                ClientId: userPoolWebClientId,
+                Storage: storage
             });
         }
 
@@ -173,14 +174,16 @@ class AuthClass {
         if (!username) { return Promise.reject('Username cannot be empty'); }
         if (!password) { return Promise.reject('Password cannot be empty'); }
 
-        const { userPoolId, userPoolWebClientId } = this._config;
+        const { userPoolId, userPoolWebClientId, storage } = this._config;
         const pool = new CognitoUserPool({
                 UserPoolId: userPoolId,
-                ClientId: userPoolWebClientId
+                ClientId: userPoolWebClientId,
+                Storage: storage
             });
         const user = new CognitoUser({
             Username: username,
-            Pool: this.userPool
+            Pool: this.userPool,
+            Storage: storage
         });
         const authDetails = new AuthenticationDetails({
             Username: username,


### PR DESCRIPTION
**Auth configuration with custom storage**  
User session is lost when app restarts. Configuration should  enable user to swap memory storage with their own so user session can be rehydrated from persistant storage.   
_Short-coming:_   
Could not use storage such as AsycnStorage directly as its methods return promise; while aws-cognito-identity-js store data with synchronous calls.
