### PR TITLE
Fixed a rendering error and a typo

### DIFF
--- a/media/storage_guide.md
+++ b/media/storage_guide.md
@@ -56,9 +56,9 @@ To create a project fully functioning with the Storage category.
 To make calls to your S3 bucket from your App, make sure CORS is turned on:
 
 1. Go to [AWS S3 Console](https://s3.console.aws.amazon.com/s3/home?region=us-east-1) and click on your project's userfiles bucket.
-2. Click on the **Permissions** tab for your bucket, and then click on **CORS confguration** tile.
+2. Click on the **Permissions** tab for your bucket, and then click on **CORS configuration** tile.
 3. Update your bucket's CORS Policy to look like:
- ```xml
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 <CORSRule>


### PR DESCRIPTION
This document currently does not render properly at https://aws.github.io/aws-amplify/media/storage_guide.html#amazon-s3-bucket-cors-policy I guess the superfluous space is the culprit; fixed a typo