### PR TITLE
fix example code syntax error on 5. Write Your Own Auth UI

### DIFF
--- a/media/authentication_guide.md
+++ b/media/authentication_guide.md
@@ -227,7 +227,7 @@ You may write your own Auth UI. JTo do this your component will leverage the fol
 This example creates an `AlwaysOn` Auth UI, which shows the current auth state.
 
 ```jsx
-import { Authenticator, SignIn, SignUp, ConfirmSignUp, Greetings } from 'aws-amplify-react’;
+import { Authenticator, SignIn, SignUp, ConfirmSignUp, Greetings } from 'aws-amplify-react';
 
 const AlwaysOn = (props) => {
     return (


### PR DESCRIPTION
I've try this example code.
https://github.com/aws/aws-amplify/blob/master/media/authentication_guide.md#5-write-your-own-auth-ui

But the code does not works.

```
./src/App.js
Syntax error: Unterminated string constant (4:72)

  2 | import logo from './logo.svg';
  3 | import './App.css';
> 4 | import { Authenticator, SignIn, SignUp, ConfirmSignUp, Greetings } from 'aws-amplify-react’;
    |                                                                         ^
  5 | import Amplify from 'aws-amplify';
  6 | 
  7 | Amplify.configure({
```

So I've made PR to fix the example code to work well.

Thanks