### PR TITLE
Export Signer interface for 3rd party HttpModules.

### DIFF
--- a/packages/aws-amplify/src/Common/index.ts
+++ b/packages/aws-amplify/src/Common/index.ts
@@ -20,6 +20,7 @@ export * from './Logger';
 export * from './Errors';
 export { default as Hub } from './Hub';
 export { default as JS } from './JS';
+export { default as Signer } from './Signer';
 
 export const Constants = {
     userAgent: 'aws-amplify/0.1.22 js'

--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -21,7 +21,8 @@ import {
     ConsoleLogger as Logger,
     Hub,
     JS,
-    ClientDevice
+    ClientDevice,
+    Signer
 } from './Common';
 
 const logger = new Logger('Amplify');
@@ -57,4 +58,4 @@ Amplify.Cache = Cache;
 
 Amplify.Logger = Logger;
 
-export { Auth, Analytics, Storage, API, I18n, Logger, Hub, Cache, JS, ClientDevice };
+export { Auth, Analytics, Storage, API, I18n, Logger, Hub, Cache, JS, ClientDevice, Signer };


### PR DESCRIPTION
We would like to use the Signer method with a third-party http module like Angular's HttpClientModule.
So Signer interface will be exposed to the outside.

and use it like this

```
import { Signer } from 'aws-amplify';
```