### PR TITLE
Auth state persistence

### DIFF
--- a/packages/aws-amplify-react-native/dist/Auth/Auth.js
+++ b/packages/aws-amplify-react-native/dist/Auth/Auth.js
@@ -81,6 +81,15 @@ class AuthClass {
                 UserPoolId: userPoolId,
                 ClientId: userPoolWebClientId
             });
+            this._userPoolStorageSync = new Promise((resolve, reject) => {
+                this.userPool.storage.sync((err, data) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(data);
+                    }
+                });
+            });
         }
 
         return this._config;
@@ -399,12 +408,9 @@ class AuthClass {
      * @return {Promise} - A promise resolves to curret CognitoUser if success
      */
     currentUser() {
-        if (!this.userPool) {
-            return Promise.reject('No userPool');
-        }
-
-        const user = this.userPool.getCurrentUser();
-        return user ? Promise.resolve(user) : Promise.reject('UserPool doesnot have current user');
+        return this._getSyncedUser().then(user => {
+            return user ? Promise.resolve(user) : Promise.reject('UserPool does not have current user');
+        });
     }
 
     /**
@@ -412,22 +418,19 @@ class AuthClass {
      * @return {Promise} - A promise resolves to curret authenticated CognitoUser if success
      */
     currentAuthenticatedUser() {
-        if (!this.userPool) {
-            return Promise.reject('No userPool');
-        }
+        return this._getSyncedUser().then(user => {
+            if (!user) {
+                return Promise.reject('No current user');
+            }
 
-        const user = this.userPool.getCurrentUser();
-        if (!user) {
-            return Promise.reject('No current user');
-        }
-
-        return new Promise((resolve, reject) => {
-            user.getSession(function (err, session) {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(user);
-                }
+            return new Promise((resolve, reject) => {
+                user.getSession(function (err, session) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(user);
+                    }
+                });
             });
         });
     }
@@ -437,15 +440,12 @@ class AuthClass {
      * @return {Promise} - A promise resolves to session object if success
      */
     currentUserSession() {
-        if (!this.userPool) {
-            return Promise.reject('No userPool');
-        }
-
-        const user = this.userPool.getCurrentUser();
-        if (!user) {
-            return Promise.reject('No current user');
-        }
-        return this.userSession(user);
+        return this._getSyncedUser().then(user => {
+            if (!user) {
+                return Promise.reject('No current user');
+            }
+            return this.userSession(user);
+        });
     }
 
     /**
@@ -572,20 +572,17 @@ class AuthClass {
      * @return {Promise} - A promise resolved if success
      */
     signOut() {
-        if (!this.userPool) {
-            return Promise.reject('No userPool');
-        }
+        return this._getSyncedUser().then(user => {
+            if (!user) {
+                return Promise.resolve();
+            }
 
-        const user = this.userPool.getCurrentUser();
-        if (!user) {
-            return Promise.resolve();
-        }
-
-        const _auth = this;
-        return new Promise((resolve, reject) => {
-            user.signOut();
-            _auth.currentCredentials().then(credentials => dispatchCredentialsChange(credentials)).catch(err => logger.error('get credentials failed', err));
-            resolve();
+            const _auth = this;
+            return new Promise((resolve, reject) => {
+                user.signOut();
+                _auth.currentCredentials().then(credentials => dispatchCredentialsChange(credentials)).catch(err => logger.error('get credentials failed', err));
+                resolve();
+            });
         });
     }
 
@@ -776,6 +773,17 @@ class AuthClass {
             });
         }
         return obj;
+    }
+
+    _getSyncedUser() {
+        const that = this;
+        return (this._userPoolStorageSync || Promise.resolve()).then(result => {
+            if (!that.userPool) {
+                return Promise.reject('No userPool');
+            }
+
+            return that.userPool.getCurrentUser();
+        });
     }
 }
 

--- a/packages/aws-amplify-react-native/dist/components/AmplifyI18n.js
+++ b/packages/aws-amplify-react-native/dist/components/AmplifyI18n.js
@@ -13,6 +13,7 @@
 
 export default dict = {
     'fr': {
+        'Loading...': "S'il vous plaît, attendez",
         'Sign In': "Se connecter",
         'Sign Up': "S'inscrire",
         'Sign Out': "Déconnexion",
@@ -43,6 +44,7 @@ Veuillez utiliser un format de numéro de téléphone du +12345678900`
     },
 
     'es': {
+        'Loading...': "Espere por favor",
         'Sign In': "Registrarse",
         'Sign Up': "Regístrate",
         'Sign Out': "Desconectar",
@@ -73,6 +75,7 @@ Utilice el formato de número de teléfono +12345678900`
     },
 
     'zh': {
+        'Loading...': "请稍候",
         'Sign In': "登录",
         'Sign Up': "注册",
         'Sign Out': "退出",

--- a/packages/aws-amplify-react-native/dist/components/auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/dist/components/auth/Authenticator.js
@@ -21,6 +21,7 @@ import { ConsoleLogger as Logger } from '../../Common';
 import AmplifyTheme from '../AmplifyTheme';
 import AmplifyMessageMap from '../AmplifyMessageMap';
 
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import VerifyContact from './VerifyContact';
@@ -57,7 +58,7 @@ export default class Authenticator extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            authState: props.authState || 'signIn',
+            authState: props.authState || 'loading',
             authData: props.authData
         };
 
@@ -97,7 +98,10 @@ export default class Authenticator extends React.Component {
         Auth.currentUser().then(user => {
             const state = user ? 'signedIn' : 'signIn';
             this.handleStateChange(state, user);
-        }).catch(err => logger.error(err));
+        }).catch(err => {
+            this.handleStateChange('signIn', null);
+            logger.error(err);
+        });
     }
 
     render() {
@@ -107,7 +111,7 @@ export default class Authenticator extends React.Component {
 
         const { hideDefault } = this.props;
         const props_children = this.props.children || [];
-        const default_children = [React.createElement(SignIn, null), React.createElement(ConfirmSignIn, null), React.createElement(VerifyContact, null), React.createElement(SignUp, null), React.createElement(ConfirmSignUp, null), React.createElement(ForgotPassword, null), React.createElement(RequireNewPassword, null), React.createElement(Greetings, null)];
+        const default_children = [React.createElement(Loading, null), React.createElement(SignIn, null), React.createElement(ConfirmSignIn, null), React.createElement(VerifyContact, null), React.createElement(SignUp, null), React.createElement(ConfirmSignUp, null), React.createElement(ForgotPassword, null), React.createElement(RequireNewPassword, null), React.createElement(Greetings, null)];
         const children = (hideDefault ? [] : default_children).concat(props_children).map((child, index) => {
             return React.cloneElement(child, {
                 key: 'auth_piece_' + index,

--- a/packages/aws-amplify-react-native/dist/components/auth/Loading.js
+++ b/packages/aws-amplify-react-native/dist/components/auth/Loading.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import React from 'react';
+import { View, Text } from 'react-native';
+import AuthPiece from './AuthPiece';
+import { Header } from '../AmplifyUI';
+
+export default class SignIn extends AuthPiece {
+    render() {
+        if (!['loading'].includes(this.props.authState)) {
+            return null;
+        }
+
+        const theme = this.props.theme || AmplifyTheme;
+        return React.createElement(
+            View,
+            { style: theme.section },
+            React.createElement(
+                Header,
+                { theme: theme },
+                I18n.get('Loading...')
+            )
+        );
+    }
+}

--- a/packages/aws-amplify-react-native/dist/components/auth/Loading.js
+++ b/packages/aws-amplify-react-native/dist/components/auth/Loading.js
@@ -16,7 +16,7 @@ import { View, Text } from 'react-native';
 import AuthPiece from './AuthPiece';
 import { Header } from '../AmplifyUI';
 
-export default class SignIn extends AuthPiece {
+export default class Loading extends AuthPiece {
     render() {
         if (!['loading'].includes(this.props.authState)) {
             return null;

--- a/packages/aws-amplify-react-native/dist/components/auth/index.js
+++ b/packages/aws-amplify-react-native/dist/components/auth/index.js
@@ -20,6 +20,7 @@ import { ConsoleLogger as Logger } from '../../Common';
 
 import Authenticator from './Authenticator';
 import AuthPiece from './AuthPiece';
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import SignUp from './SignUp';
@@ -31,7 +32,7 @@ import Greetings from './Greetings';
 
 const logger = new Logger('auth components');
 
-export { Authenticator, AuthPiece, SignIn, ConfirmSignIn, SignUp, ConfirmSignUp, ForgotPassword, RequireNewPassword, VerifyContact, Greetings };
+export { Authenticator, AuthPiece, SignIn, ConfirmSignIn, SignUp, ConfirmSignUp, ForgotPassword, Loading, RequireNewPassword, VerifyContact, Greetings };
 
 export function withAuthenticator(Comp, includeGreetings = false) {
     class Wrapper extends React.Component {

--- a/packages/aws-amplify-react-native/src/components/AmplifyI18n.js
+++ b/packages/aws-amplify-react-native/src/components/AmplifyI18n.js
@@ -13,6 +13,7 @@
 
 export default dict = {
     'fr': {
+        'Loading...': "S'il vous plaît, attendez",
         'Sign In': "Se connecter",
         'Sign Up': "S'inscrire",
         'Sign Out': "Déconnexion",
@@ -44,6 +45,7 @@ Veuillez utiliser un format de numéro de téléphone du +12345678900`
     },
 
     'es': {
+        'Loading...': "Espere por favor",
         'Sign In': "Registrarse",
         'Sign Up': "Regístrate",
         'Sign Out': "Desconectar",
@@ -75,6 +77,7 @@ Utilice el formato de número de teléfono +12345678900`
     },
 
     'zh': {
+        'Loading...': "请稍候",
         'Sign In': "登录",
         'Sign Up': "注册",
         'Sign Out': "退出",

--- a/packages/aws-amplify-react-native/src/components/auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/src/components/auth/Authenticator.js
@@ -21,6 +21,7 @@ import { ConsoleLogger as Logger } from '../../Common';
 import AmplifyTheme from '../AmplifyTheme';
 import AmplifyMessageMap from '../AmplifyMessageMap';
 
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import VerifyContact from './VerifyContact';
@@ -59,7 +60,7 @@ export default class Authenticator extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            authState: props.authState || 'signIn',
+            authState: props.authState || 'loading',
             authData: props.authData
         };
 
@@ -95,7 +96,10 @@ export default class Authenticator extends React.Component {
                 const state = user? 'signedIn' : 'signIn';
                 this.handleStateChange(state, user)
             })
-            .catch(err => logger.error(err));
+            .catch(err => {
+                this.handleStateChange('signIn', null);
+                logger.error(err);
+            });
     }
 
     render() {
@@ -106,6 +110,7 @@ export default class Authenticator extends React.Component {
         const { hideDefault } = this.props;
         const props_children = this.props.children || [];
         const default_children = [
+            <Loading/>,
             <SignIn/>,
             <ConfirmSignIn/>,
             <VerifyContact/>,

--- a/packages/aws-amplify-react-native/src/components/auth/Loading.js
+++ b/packages/aws-amplify-react-native/src/components/auth/Loading.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import React from 'react';
+import { View, Text } from 'react-native';
+import AuthPiece from './AuthPiece';
+import { Header } from '../AmplifyUI';
+
+export default class SignIn extends AuthPiece {
+    render() {
+        if (!['loading'].includes(this.props.authState)) {
+            return null;
+        }
+
+        const theme = this.props.theme || AmplifyTheme;
+        return (
+            <View style={theme.section}>
+                <Header theme={theme}>{I18n.get('Loading...')}</Header>
+            </View>
+        );
+    }
+}

--- a/packages/aws-amplify-react-native/src/components/auth/Loading.js
+++ b/packages/aws-amplify-react-native/src/components/auth/Loading.js
@@ -16,7 +16,7 @@ import { View, Text } from 'react-native';
 import AuthPiece from './AuthPiece';
 import { Header } from '../AmplifyUI';
 
-export default class SignIn extends AuthPiece {
+export default class Loading extends AuthPiece {
     render() {
         if (!['loading'].includes(this.props.authState)) {
             return null;

--- a/packages/aws-amplify-react-native/src/components/auth/index.js
+++ b/packages/aws-amplify-react-native/src/components/auth/index.js
@@ -18,6 +18,7 @@ import { ConsoleLogger as Logger } from '../../Common';
 
 import Authenticator from './Authenticator';
 import AuthPiece from './AuthPiece';
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import SignUp from './SignUp';
@@ -37,6 +38,7 @@ export {
     SignUp,
     ConfirmSignUp,
     ForgotPassword,
+    Loading,
     RequireNewPassword,
     VerifyContact,
     Greetings


### PR DESCRIPTION
When using out-of-the-box `withAuthenticator`, the user authorization will not persist across sessions (i.e. when you reload the app). This commit adds persistence of the auth state across sessions, by using the `sync` method added to the react-native-aws-cognito-js library here: https://github.com/AirLabsTeam/react-native-aws-cognito-js/blob/master/src/StorageHelper.js#L71 (it uses the React Native AsyncStorage under the hood).

Please see the commit message for commentary on the second commit in this PR.