### PR TITLE
Add Loading page for React Native authenticator

### DIFF
--- a/packages/aws-amplify-react-native/dist/AmplifyI18n.js
+++ b/packages/aws-amplify-react-native/dist/AmplifyI18n.js
@@ -13,6 +13,7 @@
 
 export default dict = {
     'fr': {
+        'Loading...': "S'il vous plaît, attendez",
         'Sign In': "Se connecter",
         'Sign Up': "S'inscrire",
         'Sign Out': "Déconnexion",
@@ -43,6 +44,7 @@ Veuillez utiliser un format de numéro de téléphone du +12345678900`
     },
 
     'es': {
+        'Loading...': "Espere por favor",
         'Sign In': "Registrarse",
         'Sign Up': "Regístrate",
         'Sign Out': "Desconectar",
@@ -73,6 +75,7 @@ Utilice el formato de número de teléfono +12345678900`
     },
 
     'zh': {
+        'Loading...': "请稍候",
         'Sign In': "登录",
         'Sign Up': "注册",
         'Sign Out': "退出",

--- a/packages/aws-amplify-react-native/dist/Auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/dist/Auth/Authenticator.js
@@ -16,6 +16,7 @@ import { View } from 'react-native';
 import { Auth, Analytics, Logger } from 'aws-amplify';
 import AmplifyTheme from '../AmplifyTheme';
 import AmplifyMessageMap from '../AmplifyMessageMap';
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import VerifyContact from './VerifyContact';
@@ -52,7 +53,7 @@ export default class Authenticator extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            authState: props.authState || 'signIn',
+            authState: props.authState || 'loading',
             authData: props.authData
         };
 
@@ -92,7 +93,10 @@ export default class Authenticator extends React.Component {
         Auth.currentAuthenticatedUser().then(user => {
             const state = user ? 'signedIn' : 'signIn';
             this.handleStateChange(state, user);
-        }).catch(err => logger.error(err));
+        }).catch(err => {
+            this.handleStateChange('signIn', null);
+            logger.error(err);
+        });
     }
 
     render() {
@@ -102,7 +106,7 @@ export default class Authenticator extends React.Component {
 
         const { hideDefault, federated } = this.props;
         const props_children = this.props.children || [];
-        const default_children = [React.createElement(SignIn, { federated: federated }), React.createElement(ConfirmSignIn, null), React.createElement(VerifyContact, null), React.createElement(SignUp, null), React.createElement(ConfirmSignUp, null), React.createElement(ForgotPassword, null), React.createElement(RequireNewPassword, null), React.createElement(Greetings, null)];
+        const default_children = [React.createElement(Loading, null), React.createElement(SignIn, { federated: federated }), React.createElement(ConfirmSignIn, null), React.createElement(VerifyContact, null), React.createElement(SignUp, null), React.createElement(ConfirmSignUp, null), React.createElement(ForgotPassword, null), React.createElement(RequireNewPassword, null), React.createElement(Greetings, null)];
         const children = (hideDefault ? [] : default_children).concat(props_children).map((child, index) => {
             return React.cloneElement(child, {
                 key: 'auth_piece_' + index,

--- a/packages/aws-amplify-react-native/dist/Auth/Loading.js
+++ b/packages/aws-amplify-react-native/dist/Auth/Loading.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import React from 'react';
+import { View, Text } from 'react-native';
+import { I18n } from 'aws-amplify';
+import AuthPiece from './AuthPiece';
+import { Header } from '../AmplifyUI';
+
+export default class Loading extends AuthPiece {
+    render() {
+        if (!['loading'].includes(this.props.authState)) {
+            return null;
+        }
+
+        const theme = this.props.theme || AmplifyTheme;
+        return React.createElement(
+            View,
+            { style: theme.section },
+            React.createElement(
+                Header,
+                { theme: theme },
+                I18n.get('Loading...')
+            )
+        );
+    }
+}

--- a/packages/aws-amplify-react-native/dist/Auth/Loading.js
+++ b/packages/aws-amplify-react-native/dist/Auth/Loading.js
@@ -18,12 +18,13 @@ import AuthPiece from './AuthPiece';
 import { Header } from '../AmplifyUI';
 
 export default class Loading extends AuthPiece {
-    render() {
-        if (!['loading'].includes(this.props.authState)) {
-            return null;
-        }
+    constructor(props) {
+        super(props);
 
-        const theme = this.props.theme || AmplifyTheme;
+        this._validAuthStates = ['loading'];
+    }
+
+    showComponent(theme) {
         return React.createElement(
             View,
             { style: theme.section },

--- a/packages/aws-amplify-react-native/dist/Auth/index.js
+++ b/packages/aws-amplify-react-native/dist/Auth/index.js
@@ -18,6 +18,7 @@ import { View } from 'react-native';
 import { Logger } from 'aws-amplify';
 import Authenticator from './Authenticator';
 import AuthPiece from './AuthPiece';
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import SignUp from './SignUp';
@@ -29,7 +30,7 @@ import Greetings from './Greetings';
 
 const logger = new Logger('auth components');
 
-export { Authenticator, AuthPiece, SignIn, ConfirmSignIn, SignUp, ConfirmSignUp, ForgotPassword, RequireNewPassword, VerifyContact, Greetings };
+export { Authenticator, AuthPiece, SignIn, ConfirmSignIn, SignUp, ConfirmSignUp, ForgotPassword, Loading, RequireNewPassword, VerifyContact, Greetings };
 
 export function withAuthenticator(Comp, includeGreetings = false, authenticatorComponents = []) {
     class Wrapper extends React.Component {

--- a/packages/aws-amplify-react-native/src/AmplifyI18n.js
+++ b/packages/aws-amplify-react-native/src/AmplifyI18n.js
@@ -13,6 +13,7 @@
 
 export default dict = {
     'fr': {
+        'Loading...': "S'il vous plaît, attendez",
         'Sign In': "Se connecter",
         'Sign Up': "S'inscrire",
         'Sign Out': "Déconnexion",
@@ -44,6 +45,7 @@ Veuillez utiliser un format de numéro de téléphone du +12345678900`
     },
 
     'es': {
+        'Loading...': "Espere por favor",
         'Sign In': "Registrarse",
         'Sign Up': "Regístrate",
         'Sign Out': "Desconectar",
@@ -75,6 +77,7 @@ Utilice el formato de número de teléfono +12345678900`
     },
 
     'zh': {
+        'Loading...': "请稍候",
         'Sign In': "登录",
         'Sign Up': "注册",
         'Sign Out': "退出",

--- a/packages/aws-amplify-react-native/src/Auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/src/Auth/Authenticator.js
@@ -20,6 +20,7 @@ import {
 } from 'aws-amplify';
 import AmplifyTheme from '../AmplifyTheme';
 import AmplifyMessageMap from '../AmplifyMessageMap';
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import VerifyContact from './VerifyContact';
@@ -58,7 +59,7 @@ export default class Authenticator extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            authState: props.authState || 'signIn',
+            authState: props.authState || 'loading',
             authData: props.authData
         };
 
@@ -94,7 +95,10 @@ export default class Authenticator extends React.Component {
                 const state = user? 'signedIn' : 'signIn';
                 this.handleStateChange(state, user)
             })
-            .catch(err => logger.error(err));
+            .catch(err => {
+                this.handleStateChange('signIn', null);
+                logger.error(err);
+            });
     }
 
     render() {
@@ -105,6 +109,7 @@ export default class Authenticator extends React.Component {
         const { hideDefault, federated } = this.props;
         const props_children = this.props.children || [];
         const default_children = [
+            <Loading/>,
             <SignIn federated={federated} />,
             <ConfirmSignIn/>,
             <VerifyContact/>,

--- a/packages/aws-amplify-react-native/src/Auth/Loading.js
+++ b/packages/aws-amplify-react-native/src/Auth/Loading.js
@@ -18,12 +18,13 @@ import AuthPiece from './AuthPiece';
 import { Header } from '../AmplifyUI';
 
 export default class Loading extends AuthPiece {
-    render() {
-        if (!['loading'].includes(this.props.authState)) {
-            return null;
-        }
+    constructor(props) {
+        super(props);
 
-        const theme = this.props.theme || AmplifyTheme;
+        this._validAuthStates = ['loading'];
+    }
+
+    showComponent(theme) {
         return (
             <View style={theme.section}>
                 <Header theme={theme}>{I18n.get('Loading...')}</Header>

--- a/packages/aws-amplify-react-native/src/Auth/Loading.js
+++ b/packages/aws-amplify-react-native/src/Auth/Loading.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import React from 'react';
+import { View, Text } from 'react-native';
+import { I18n } from 'aws-amplify';
+import AuthPiece from './AuthPiece';
+import { Header } from '../AmplifyUI';
+
+export default class Loading extends AuthPiece {
+    render() {
+        if (!['loading'].includes(this.props.authState)) {
+            return null;
+        }
+
+        const theme = this.props.theme || AmplifyTheme;
+        return (
+            <View style={theme.section}>
+                <Header theme={theme}>{I18n.get('Loading...')}</Header>
+            </View>
+        );
+    }
+}

--- a/packages/aws-amplify-react-native/src/Auth/index.js
+++ b/packages/aws-amplify-react-native/src/Auth/index.js
@@ -16,6 +16,7 @@ import { View } from 'react-native';
 import { Logger } from 'aws-amplify';
 import Authenticator from './Authenticator';
 import AuthPiece from './AuthPiece';
+import Loading from './Loading';
 import SignIn from './SignIn';
 import ConfirmSignIn from './ConfirmSignIn';
 import SignUp from './SignUp';
@@ -35,6 +36,7 @@ export {
     SignUp,
     ConfirmSignUp,
     ForgotPassword,
+    Loading,
     RequireNewPassword,
     VerifyContact,
     Greetings


### PR DESCRIPTION
This is necessary because Auth.currentAuthenticatedUser() returns a Promise.
When a user is logged in and the app is reloaded, there is a brief flicker
during which the SignIn screen is shown before the authenticated app
appears. This Loading screen replaces that flicker and will toggle to
either signIn or signedIn, as appropriate.