### PR TITLE
Add safe check for navigator variable

### DIFF
--- a/packages/aws-amplify/src/Common/Platform/index.ts
+++ b/packages/aws-amplify/src/Common/Platform/index.ts
@@ -17,7 +17,7 @@ const Platform = {
 	'navigator': null,
 	'isReactNative': false
 };
-if (navigator && navigator.product) {
+if (typeof navigator !== 'undefined' && navigator.product) {
 	Platform.product = navigator.product || '';
 	Platform.navigator = navigator || null;
 	switch(navigator.product) {


### PR DESCRIPTION
Hi guys,

I'm using `awsmobile-cli` to configure a cloud-api for the project and the following command `awsmobile cloud-api invoke CloudApiTest <method> <path> [init]` is failing with an error

```
cloud-api invoke error:
ReferenceError: navigator is not defined
    at Object.<anonymous> (/usr/local/lib/node_modules/awsmobile-cli/node_modules/aws-amplify/lib/Common/Platform/index.js:21:1)
```

So I've added this safe check for `navigator` variable.
Please let me know what you think on this.

Thank you!