### PR TITLE
Restrict Typescript to < 2.7.0 to avoid a problem with the lodash type definitions

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -44,7 +44,7 @@
     "tslint": "^5.7.0",
     "tslint-config-airbnb": "^5.3.0",
     "typedoc-dep-update": "^0.9.0",
-    "typescript": "^2.4.2",
+    "typescript": ">=2.4.2 <2.7.0",
     "typescript-formatter": "^6.0.0",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^3.5.5"


### PR DESCRIPTION
A fresh checkout won't build due to an incompatibility between Typescript 2.7 and the lodash definition. This PR restricts Typescript to >= 2.4.2 (the old minimum version) and < 2.7 so that it installs a version that can build the source.