### PR TITLE
Change repository URL and info on license

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -24,9 +24,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/aws/amazon-cognito-identity-js.git"
+    "url": "https://github.com/aws/aws-amplify.git"
   },
-  "license": "SEE LICENSE IN LICENSE.txt",
+  "license": "See LICENSE",
   "licenses": [
     {
       "type": "Amazon Software License",


### PR DESCRIPTION
*Description of changes:*

- Change repo url to https://github.com/aws/aws-amplify.git
- Change license info to point to`LICENSE` since `LICENSE.txt` does not exists in the `aws-amplify` repo.

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
