### PR TITLE
Cognito cookie storage

### DIFF
--- a/docs/media/authentication_guide.md
+++ b/docs/media/authentication_guide.md
@@ -58,7 +58,18 @@ Amplify.configure({
     // OPTIONAL - Amazon Cognito Web Client ID
         userPoolWebClientId: 'XX-XXXX-X_abcd1234',
     // OPTIONAL - Enforce user authentication prior to accessing AWS resources or not
-        mandatorySignIn: false
+        mandatorySignIn: false,
+    // OPTIONAL - Configuration for cookie storage
+        cookieStorage: {
+        // REQUIRED - Cookie domain (only required if cookieStorage is provided)
+            domain: '.yourdomain.com',
+        // OPTIONAL - Cookie path
+            path: '/',
+        // OPTIONAL - Cookie expiration in days
+            expires: 365,
+        // OPTIONAL - Cookie secure flag
+            secure: true
+        }
     }
 });
 ```

--- a/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
+++ b/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
@@ -1,5 +1,3 @@
-import { CookieStorage } from "amazon-cognito-identity-js";
-
 jest.mock('aws-sdk/clients/pinpoint', () => {
     const Pinpoint = () => {
         var pinpoint = null;
@@ -140,7 +138,7 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
 import { AuthOptions, SignUpParams } from '../../src/Auth/types';
 import Auth from '../../src/Auth/Auth';
 import Cache from '../../src/Cache';
-import { CognitoUserPool, CognitoUser, CognitoUserSession, CognitoIdToken, CognitoAccessToken } from 'amazon-cognito-identity-js';
+import { CookieStorage, CognitoUserPool, CognitoUser, CognitoUserSession, CognitoIdToken, CognitoAccessToken } from 'amazon-cognito-identity-js';
 import { CognitoIdentityCredentials } from 'aws-sdk';
 
 const authOptions: AuthOptions = {

--- a/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
+++ b/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
@@ -1,3 +1,5 @@
+import { CookieStorage } from "amazon-cognito-identity-js";
+
 jest.mock('aws-sdk/clients/pinpoint', () => {
     const Pinpoint = () => {
         var pinpoint = null;
@@ -408,6 +410,25 @@ describe('auth unit test', () => {
             const user = new CognitoUser({
                 Username: 'username',
                 Pool: userPool
+            });
+
+            expect.assertions(1);
+            expect(await auth.signIn('username', 'password')).toEqual(user);
+
+            spyon.mockClear();
+        });
+
+        test('happy case using cookie storage', async () => {
+            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser')
+                .mockImplementationOnce((authenticationDetails, callback) => {
+                    callback.onSuccess(session);
+                });
+
+            const auth = new Auth({ ...authOptions, cookieStorage: { domain: ".example.com" } });
+            const user = new CognitoUser({
+                Username: 'username',
+                Pool: userPool,
+                Storage: new CookieStorage({domain: ".yourdomain.com"})
             });
 
             expect.assertions(1);

--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -22,7 +22,7 @@ import {
 } from '../Common';
 import Platform from '../Common/Platform';
 import Cache from '../Cache';
-import { CookieStorage, ICognitoUserPoolData, ICognitoUserData } from 'amazon-cognito-identity-js';
+import { ICognitoUserPoolData, ICognitoUserData } from 'amazon-cognito-identity-js';
 
 const logger = new Logger('AuthClass');
 
@@ -31,6 +31,7 @@ const {
 } = AWS;
 
 const {
+    CookieStorage,
     CognitoUserPool,
     CognitoUserAttribute,
     CognitoUser,

--- a/packages/aws-amplify/src/Auth/types/Auth.ts
+++ b/packages/aws-amplify/src/Auth/types/Auth.ts
@@ -11,6 +11,8 @@
  * and limitations under the License.
  */
 
+ import { ICookieStorageData } from "amazon-cognito-identity-js";
+
 /**
 * Parameters for user sign up
 */
@@ -29,6 +31,7 @@ export interface AuthOptions {
     identityPoolId: string,
     region?: string,
     mandatorySignIn: boolean
+    cookieStorage?: ICookieStorageData,
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*

#179 

*Description of changes:*

Add a new option `cookieStorage` to the manual setup for `Auth`. This parameter is the params passed to `CognitoUserPool` and `CognitoUser` as described in _Use case 26. Using cookies to store cognito tokens_ on https://github.com/aws/aws-amplify/tree/master/packages/amazon-cognito-identity-js

By setting this Cognito will store the tokens in a cookie allowing them to be used across subdomains.

If this option is not set then everything will work as is.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
