### PR TITLE
Add support for developer authenticated strategies

### DIFF
--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -761,12 +761,13 @@ export default class AuthClass {
         const domains = {
             'google': 'accounts.google.com',
             'facebook': 'graph.facebook.com',
-            'amazon': 'www.amazon.com'
+            'amazon': 'www.amazon.com',
+            'developer': 'cognito-identity.amazonaws.com'
         };
 
         const domain = domains[provider];
         if (!domain) {
-            return Promise.reject(provider + ' is not supported: [google, facebook, amazon]');
+            return Promise.reject(provider + ' is not supported: [google, facebook, amazon, developer]');
         }
 
         const logins = {};


### PR DESCRIPTION
*Issue #, if available:*

#308 and #416

*Description of changes:*

This PR add `developer` to the list of domains`setCredentialsFromFederation()` will accept credentials for. After this change you sign in using developer authenticated credentials from a Cognito Identity Pool with `federatedSignIn()` by passing `developer` as the provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
