### PR TITLE
Binding console to console functions

### DIFF
--- a/packages/aws-amplify/src/Common/Logger/ConsoleLogger.ts
+++ b/packages/aws-amplify/src/Common/Logger/ConsoleLogger.ts
@@ -72,9 +72,9 @@ export class ConsoleLogger implements Logger {
             return;
         }
 
-        let log = console.log;
-        // if (type === 'ERROR' && console.error) { log = console.error; }
-        if (type === 'WARN' && console.warn) { log = console.warn; }
+        let log = console.log.bind(console);
+        // if (type === 'ERROR' && console.error) { log = console.error.bind(console); }
+        if (type === 'WARN' && console.warn) { log = console.warn.bind(console); }
 
         if (msg.length === 1 && typeof msg[0] === 'string') {
             const output = [


### PR DESCRIPTION
Issue #451

Using bind() to ensure that console.[log|warn|error] works in any environment.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
