### PR TITLE
add updated maven repository url

### DIFF
--- a/docs/media/push_notifications_setup.md
+++ b/docs/media/push_notifications_setup.md
@@ -66,6 +66,9 @@ Also update maven `url` as the following under  `allprojects` > `repositories`. 
                 // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
                 url "$rootDir/../node_modules/react-native/android"
             }
+            maven {
+                url "https://maven.google.com"
+            }
         }
     }
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the missing maven repository url. The documentation mentions it above, but the code snippet appears to be the React Native default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
