### PR TITLE
fixed federatedsignin not caching token

### DIFF
--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -984,7 +984,7 @@ export default class AuthClass {
         const { token, expires_at } = response;
 
         // store it into localstorage
-        // Cache.setItem('federatedInfo', { provider, token, user, expires_at }, { priority: 1 });
+        Cache.setItem('federatedInfo', { provider, token, user, expires_at }, { priority: 1 });
         const that = this;
         return new Promise((res, rej) => {
             that._setCredentialsFromFederation({ provider, token, user, expires_at }).then((cred) => {


### PR DESCRIPTION
*Issue #, if available:*
 #180

*Description of changes:*
fixed a bug introduced by 0b10deb6480cedc85179dfab42910ff74af92e88 causing federated tokens not to get cached when signing in

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
