### PR TITLE
Auth current user info fix

### DIFF
--- a/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
+++ b/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
@@ -1378,11 +1378,6 @@ describe('auth unit test', () => {
 
             const spyon2 = jest.spyOn(Auth.prototype, 'userAttributes')
                 .mockImplementationOnce(() => {
-                    auth['credentials'] = new CognitoIdentityCredentials({
-                        IdentityPoolId: 'identityPoolId',
-                        IdentityId: 'identityId'
-                    });
-                    auth['credentials']['identityId'] = 'identityId';
                     return new Promise((res, rej)=> {
                         res([
                             {Name: 'email', Value: 'email'},
@@ -1393,6 +1388,13 @@ describe('auth unit test', () => {
                         ]);
                     });
                 });
+
+            const spyon3 = jest.spyOn(Auth.prototype, 'currentCredentials').mockImplementationOnce(() => {
+                auth['credentials'] = {
+                    identityId: 'identityId'
+                }
+                return Promise.resolve();
+            });
 
             expect.assertions(1);
             expect(await auth.currentUserInfo()).toEqual({

--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -977,8 +977,17 @@ export default class AuthClass {
                 const attributes = await this.userAttributes(user);
                 const userAttrs:object = this.attributesToObject(attributes);
 
+                // check if the credentials is in the memory
+                if (!this.credentials) {
+                    try {
+                        await this.currentCredentials();
+                    } catch (e) {
+                        logger.debug('Failed to retrieve credentials while getting current user info', e);
+                    }
+                }
+
                 const info = {
-                    'id': this.credentials.identityId,
+                    'id': this.credentials? this.credentials.identityId : undefined,
                     'username': user.username,
                     'attributes': userAttrs
                 };


### PR DESCRIPTION
*Issue #, if available:*
#592 
*Description of changes:*
Fix the problem when using ```Auth.currentUserInfo()``` in the ```componentDidMount``` will return empty object

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
