### PR TITLE
Doc : Add errors from API handling examples

### DIFF
--- a/docs/media/api_guide.md
+++ b/docs/media/api_guide.md
@@ -112,6 +112,9 @@ The following code sample assumes you have used Automated Setup.
 
 To invoke an endpoint, you need to set `apiName`, `path` and `headers` parameters, and each method returns a Promise.
 
+Under the hood, aws-amplify use [Axios](https://github.com/axios/axios), so API status code response > 299 are thrown as an exception.
+If you need to handle errors managed by your API, work with the `error.response` object.
+
 ### **GET**
 
 ```js
@@ -123,6 +126,8 @@ let myInit = { // OPTIONAL
 }
 API.get(apiName, path, myInit).then(response => {
     // Add your code here
+}).catch(error => {
+    console.log(error.response)
 });
 ```
 
@@ -156,6 +161,8 @@ let myInit = {
 
 API.post(apiName, path, myInit).then(response => {
     // Add your code here
+}).catch(error => {
+    console.log(error.response)
 });
 ```
 
@@ -187,6 +194,8 @@ let myInit = {
 
 API.put(apiName, path, myInit).then(response => {
     // Add your code here
+}).catch(error => {
+    console.log(error.response)
 });
 ```
 
@@ -217,6 +226,8 @@ let myInit = { // OPTIONAL
 
 API.del(apiName, path, myInit).then(response => {
     // Add your code here
+}).catch(error => {
+    console.log(error.response)
 });
 ```
 


### PR DESCRIPTION
*Fix Issue #582*

I found out, by reading the source code, that aws-amplify is using Axios to handle http calls. This choice introduce a particular way of manage errors coming from API comparing to Fetch. (see [this issue](https://github.com/axios/axios/issues/960) )

This PR is a proposal for explicitly tell developers that Axios is used.

By doing this, it also makes much clearer the use of an `init` object (called `myInit` in the examples) as a parameter of the `get()`, `post()`, etc. methods. This object is indeed, at the end, the documented `param` parameter in the corresponding methods in Axios.

It also warn the developers that status code > 299 are thrown as an exception. Which is not obvious when using Fetch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
