### PR TITLE
fix typo in react_native_guide.md

### DIFF
--- a/docs/media/react_native_guide.md
+++ b/docs/media/react_native_guide.md
@@ -7,7 +7,7 @@ AWS Amplify provides React Native Components with `aws-amplify-react-native` npm
 
 ## Installation and Configuration
 
-Install following npm packages into your Angular app.
+Install following npm packages into your React Native app.
 
 ```bash
 $ npm install aws-amplify


### PR DESCRIPTION
Replaced "Angular" with "React Native" in the second paragraph.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
