### PR TITLE
use NetworkError code in aws-cognito-identity

### DIFF
--- a/packages/amazon-cognito-identity-js/src/Client.js
+++ b/packages/amazon-cognito-identity-js/src/Client.js
@@ -82,7 +82,7 @@ export default class Client {
         // otherwise check if error is Network error
         } else if (err instanceof Error && err.message === 'Network error') {
           error = {
-            code: err.name,
+            code: 'NetworkError',
             name: err.name,
             message: err.message,
           };


### PR DESCRIPTION

Hi,
it related to PR : https://github.com/aws/aws-amplify/pull/605

*Description of changes:*
Minor change : 
 return "NetworkError" code inside the error callback in client.js on network error instead of Error code "Error".




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
