### PR TITLE
Add hidden style

### DIFF
--- a/packages/aws-amplify-react/src/AmplifyTheme.jsx
+++ b/packages/aws-amplify-react/src/AmplifyTheme.jsx
@@ -277,6 +277,10 @@ export const Col12 = {
     width: '100%'
 }
 
+export const Hidden = {
+    display: 'none'
+}
+
 const Bootstrap = {
     container: Container,
 
@@ -316,7 +320,9 @@ const Bootstrap = {
     col9: Col9,
     col10: Col10,
     col11: Col11,
-    col12: Col12
+    col12: Col12,
+
+    hidden: Hidden,
 }
 
 export default Bootstrap;


### PR DESCRIPTION
The hidden style is mandatory for AmplifyTheme because it is used in the PhotoPicker component.

*Issue #, if available:*

The PhotoPicker component does not hide the preview with option `preview="hidden"` because there is no hidden style in AmplifyTheme as it should.
I am not sure there is a declared issue so it might be a new one. 

*Description of changes:*

This pull request adds an hidden style in AmplifyTheme to make PhotoPicker work properly with `preview="hidden"` option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
