### PR TITLE
Changed refreshing federated token logic

### DIFF
--- a/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
+++ b/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
@@ -1084,6 +1084,26 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
+        test('with federated info and not expired, then refresh it successfully', async () => {
+            const auth = new Auth(authOptions);
+
+            const spyon = jest.spyOn(Cache, 'getItem')
+                .mockImplementationOnce(() => {
+                    return {
+                        provider: 'google',
+                        token: 'token',
+                        expires_at: (new Date().getTime()) * 2
+                    }
+                });
+
+            auth._refreshHandlers = {}
+            
+            expect.assertions(1);
+            expect(await auth.currentUserCredentials()).not.toBeUndefined();
+
+            spyon.mockClear();
+        });
+
         test('with federated info and expired, then refresh it successfully', async () => {
             const auth = new Auth(authOptions);
 
@@ -1105,7 +1125,7 @@ describe('auth unit test', () => {
                 }
             }
             expect.assertions(1);
-             expect(await auth.currentUserCredentials()).not.toBeUndefined();
+            expect(await auth.currentUserCredentials()).not.toBeUndefined();
 
             spyon.mockClear();
         });

--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -857,30 +857,31 @@ export default class AuthClass {
 
         const that = this;
         logger.debug('checking if federated jwt token expired');
-        if (expires_at < new Date().getTime()
-            && typeof that._refreshHandlers[provider] === 'function') {
-            logger.debug('getting refreshed jwt token from federation provider');
-            return that._refreshHandlers[provider]().then((data) => {
-                logger.debug('refresh federated token sucessfully', data);
-                token = data.token;
-                identity_id = data.identity_id;
-                expires_at = data.expires_at;
-                // Cache.setItem('federatedInfo', { provider, token, user, expires_at }, { priority: 1 });
-                return that._setCredentialsFromFederation({ provider, token, user, identity_id, expires_at });
-            }).catch(e => {
-                logger.debug('refresh federated token failed', e);
-                this.cleanCachedItems();
-                return Promise.reject('refreshing federation token failed: ' + e);
-            });
-        } else {
-            if (!that._refreshHandlers[provider]) {
-                logger.debug('no refresh handler for provider:', provider);
-                this.cleanCachedItems();
-                return Promise.reject('no refresh handler for provider');
+        if (expires_at < new Date().getTime()) {
+            if (typeof that._refreshHandlers[provider] === 'function') {
+                logger.debug('getting refreshed jwt token from federation provider');
+                return that._refreshHandlers[provider]().then((data) => {
+                    logger.debug('refresh federated token sucessfully', data);
+                    token = data.token;
+                    identity_id = data.identity_id;
+                    expires_at = data.expires_at;
+                    // Cache.setItem('federatedInfo', { provider, token, user, expires_at }, { priority: 1 });
+                    return that._setCredentialsFromFederation({provider, token, user, identity_id, expires_at});
+                }).catch(e => {
+                    logger.debug('refresh federated token failed', e);
+                    this.cleanCachedItems();
+                    return Promise.reject('refreshing federation token failed: ' + e);
+                });
             } else {
-                logger.debug('token not expired');
-                return this._setCredentialsFromFederation({provider, token, user, identity_id, expires_at });
+                if (!that._refreshHandlers[provider]) {
+                    logger.debug('no refresh handler for provider:', provider);
+                    this.cleanCachedItems();
+                    return Promise.reject('no refresh handler for provider');
+                }
             }
+        } else {
+            logger.debug('token not expired');
+            return this._setCredentialsFromFederation({provider, token, user, identity_id, expires_at});
         }
     }
 


### PR DESCRIPTION
Closes #796 

*Description of changes:*

Changed logic of refresh to stop removing valid user if a refreshHandler is not configured for the provider.
Added a test. 

Any suggestions are welcome.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
