### PR TITLE
Set graphql dependency version to exactly 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packages/**/dist/
 .vscode
 .idea
 *.log
+.npm/

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -62,7 +62,7 @@
     "amazon-cognito-identity-js": "^2.0.0",
     "aws-sdk": "2.198.0",
     "axios": "^0.17.0",
-    "graphql": "^0.13.1",
+    "graphql": "0.13.0",
     "paho-mqtt": "^1.0.4",
     "url": "^0.11.0",
     "uuid": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4373,11 +4373,11 @@ graceful-fs@~1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
 
-graphql@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.1.tgz#9b3db3d8e40d1827e4172404bfdd2e4e17a58b55"
+graphql@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.0.tgz#d1b44a282279a9ce0a6ec1037329332f4c1079b6"
   dependencies:
-    iterall "^1.2.0"
+    iterall "1.1.x"
 
 growl@1.10.3:
   version "1.10.3"
@@ -5301,9 +5301,9 @@ istanbul@0.4.5, istanbul@^0.4.0:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-iterall@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+iterall@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.4.tgz#0db40d38fdcf53ae14dc8ec674e62ab190d52cfc"
 
 jasmine-core@^2.99.1, jasmine-core@~2.99.0:
   version "2.99.1"


### PR DESCRIPTION
*Issue #, if available:*
Fixes: #761 

*Description of changes:*
Set graphql dependency version to exactly 0.13.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
