### PR TITLE
Roll back crypto-browserify to 1.0.9

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -63,7 +63,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "buffer": "4.9.1",
-    "crypto-browserify": "3.0.0",
+    "crypto-browserify": "1.0.9",
     "js-cookie": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue #, if available:*
After upgrading to 3.0.0, we found it causes errors in Angular 6 and react native
*Description of changes:*
Rollback to the previous version. Will try to replace crypto-browserify with sjcl

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
