### PR TITLE
fix: setPreferredMFA method throws error when setting totp with no cellphone

### DIFF
--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -370,10 +370,7 @@ export default class AuthClass {
      * @return - A promise resolve if success
      */
     public setPreferredMFA(user : any, mfaMethod : string): Promise<any> {
-        let smsMfaSettings = {
-            PreferredMfa : false,
-            Enabled : false
-        };
+        let smsMfaSettings = null;
         let totpMfaSettings = {
             PreferredMfa : false,
             Enabled : false
@@ -742,7 +739,7 @@ export default class AuthClass {
             } catch (e) {
                 logger.debug('cannot get user attributes');
             } finally {
-                this.user = Object.assign({}, user, { attributes });
+                this.user = Object.assign(user, { attributes });
                 return this.user;
             }
         }


### PR DESCRIPTION
*Issue #, if available:*
fixes #806 #618 #846
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
