### PR TITLE
fix(API):Move credential check inside AWS_IAM auth switch

### DIFF
--- a/packages/aws-amplify/src/API/API.ts
+++ b/packages/aws-amplify/src/API/API.ts
@@ -284,8 +284,6 @@ export default class APIClass {
         } = this._options;
         let headers = {};
 
-        const credentialsOK = await this._ensureCredentials();
-
         switch (authenticationType) {
             case 'API_KEY':
                 headers = {
@@ -294,6 +292,7 @@ export default class APIClass {
                 };
                 break;
             case 'AWS_IAM':
+                const credentialsOK = await this._ensureCredentials();
                 if (!credentialsOK) { throw new Error('No credentials'); }
                 break;
             case 'OPENID_CONNECT':

--- a/packages/aws-amplify/src/API/API.ts
+++ b/packages/aws-amplify/src/API/API.ts
@@ -61,6 +61,7 @@ export default class APIClass {
                 opt.endpoints = (typeof custom === 'string') ? JSON.parse(custom)
                     : custom;
             }
+            
             opt = Object.assign({}, opt, {
                 region: opt['aws_project_region'],
                 header: {},


### PR DESCRIPTION
Move credential check inside AWS_IAM auth switch for GraphQL requests to prevent unnecessary warnings

Fixes #726

*Issue #, if available:*
#726 

*Description of changes:*
GraphQL requests performed a credential check no matter the auth type. This change moves the credential check inside of the auth type that needs it (AWS_IAM)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
