### PR TITLE
fix(aws-amplify-react): VerifyContact Skip link passes user data

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/VerifyContact-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/VerifyContact-test.js
@@ -111,13 +111,14 @@ describe.only('VerifyContent test', () => {
             const wrapper = shallow(<VerifyContact/>);
             const props = {
                 authState: 'verifyContact',
+                authData: 'user',
                 theme: 'theme'
             }
             wrapper.setProps(props);
 
             wrapper.find(Link).simulate('click');
 
-            expect(spyon).toBeCalledWith('signedIn');
+            expect(spyon).toBeCalledWith('signedIn', 'user');
 
             spyon.mockClear();
         });

--- a/packages/aws-amplify-react/src/Auth/VerifyContact.jsx
+++ b/packages/aws-amplify-react/src/Auth/VerifyContact.jsx
@@ -37,6 +37,7 @@ export default class VerifyContact extends AuthPiece {
         this._validAuthStates = ['verifyContact'];
         this.verify = this.verify.bind(this);
         this.submit = this.submit.bind(this);
+        this.skip = this.skip.bind(this);
 
         this.state = { verifyAttr: null }
     }
@@ -66,6 +67,10 @@ export default class VerifyContact extends AuthPiece {
                 this.setState({ verifyAttr: null });
             })
             .catch(err => this.error(err));
+    }
+
+    skip() {
+        this.changeState('signedIn', this.props.authData);
     }
 
     verifyView() {
@@ -123,7 +128,7 @@ export default class VerifyContact extends AuthPiece {
     }
 
     showComponent(theme) {
-        const { authData, hide } = this.props;
+        const { hide } = this.props;
         if (hide && hide.includes(VerifyContact)) { return null; }
 
         return (
@@ -136,7 +141,7 @@ export default class VerifyContact extends AuthPiece {
                     { this.state.verifyAttr? this.submitView() : this.verifyView() }
                 </SectionBody>
                 <SectionFooter theme={theme}>
-                    <Link theme={theme} onClick={() => this.changeState('signedIn')}>
+                    <Link theme={theme} onClick={this.skip}>
                         {I18n.get('Skip')}
                     </Link>
                 </SectionFooter>


### PR DESCRIPTION

*Issue #, if available:*

Fixes #982

*Description of changes:*

When clicking "Skip" on the VerifyContact page, undefined was being passed for authData. Fixed to pass the current authData.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
