### PR TITLE
Fix minor protocol typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ __Without AWS__
 ```js
 Amplify.configure({
   API: {
-    graphql_endpoint: 'https:/www.example.com/my-graphql-endpoint'
+    graphql_endpoint: 'https://www.example.com/my-graphql-endpoint'
   }
 });
 ```
@@ -221,7 +221,7 @@ To access a GraphQL API with your app, you need to make sure to configure the en
 // Configure a custom GraphQL endpoint
 Amplify.configure({
   API: {
-    graphql_endpoint: 'https:/www.example.com/my-graphql-endpoint'
+    graphql_endpoint: 'https://www.example.com/my-graphql-endpoint'
   }
 });
 


### PR DESCRIPTION
*Description of changes:*
This is a very minor typo but I would like to correct it. `https` protocol should comes with two slashes but the original README contains only one slash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
