### PR TITLE
do not raise error on pluggable configuration

### DIFF
--- a/packages/aws-amplify/src/Interactions/Interactions.ts
+++ b/packages/aws-amplify/src/Interactions/Interactions.ts
@@ -79,7 +79,6 @@ export default class Interactions {
                 throw new Error('Bot ' + pluggable.getProviderName() + ' already plugged');
             }
         }
-        throw new Error('Bot ' + pluggable.getProviderName() + ' has wrong category');
     }
 
     public async send(botname: string, message: string | Object) {


### PR DESCRIPTION
Fixes #1075 

*Description of changes:*

Do not raise an error in `Interactions.addPluggable` if type `pluggable.getProviderName()` does not match, just silently ignore it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
