### PR TITLE
Update AWSLexProvider.ts to send all data back

### DIFF
--- a/packages/aws-amplify/src/Interactions/Providers/AWSLexProvider.ts
+++ b/packages/aws-amplify/src/Interactions/Providers/AWSLexProvider.ts
@@ -65,11 +65,11 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
                         logger.debug('postText state', data.dialogState);
                         if (data.dialogState === 'ReadyForFulfillment' || data.dialogState === 'Fulfilled') {
                             if (typeof this._botsCompleteCallback[botname] === 'function') {
-                                setTimeout(() => this._botsCompleteCallback[botname](null, { slots: data.slots }), 0);
+                                setTimeout(() => this._botsCompleteCallback[botname](null, data), 0);
                             }
                             
                             if (this._config && typeof this._config[botname].onComplete === 'function') {
-                                setTimeout(() => this._config[botname].onComplete(null, { slots: data.slots }), 0);
+                                setTimeout(() => this._config[botname].onComplete(null, data), 0);
                             }
                         }
                         


### PR DESCRIPTION
Update AWSLexProvider.ts to send all `data` (and not just `data.slots`) received from the Lex `postText` API to the `onComplete` callback.

*Issue #, if available:*

#1166

*Description of changes:*

Replacing `{ data.slots }` with `data` in the callback parameter after the Amazon Lex postText API call. The change is adding more properties (such as `intentName` and `sessionAttributes `) to the returned object, so that more information is available on the client, without breaking the previous behavior (the same `slots` property is still there).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.