### PR TITLE
React federated sign in fix

### DIFF
--- a/packages/aws-amplify-react/.babelrc
+++ b/packages/aws-amplify-react/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["es2015", "react", "es2017"]
+  "presets": ["es2015", "react", "es2017"],
+  "plugins": [
+    ["transform-runtime", {
+      "polyfill": false,
+      "regenerator": true
+    }]
+  ]
 }

--- a/packages/aws-amplify-react/__tests__/Auth/Provider/withAmazon-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/Provider/withAmazon-test.js
@@ -104,6 +104,10 @@ describe('withAmazon test', () => {
             const wrapper = shallow(<Comp/>);
             const comp = wrapper.instance();
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+            
             const spyon = jest.spyOn(Auth, 'federatedSignIn').mockImplementationOnce(() => { 
                 return new Promise((res, rej) => {
                     res('credentials');
@@ -117,6 +121,7 @@ describe('withAmazon test', () => {
 
             spyon.mockClear();
             spyon2.mockClear();
+            spyon_currentUser.mockClear();
         });
 
         test('happy case with onStateChange exists', async () => {
@@ -152,6 +157,10 @@ describe('withAmazon test', () => {
                 onStateChange: mockFn
             });
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+
             const spyon = jest.spyOn(Auth, 'federatedSignIn').mockImplementationOnce(() => { 
                 return new Promise((res, rej) => {
                     res('credentials');
@@ -162,10 +171,10 @@ describe('withAmazon test', () => {
             await comp.federatedSignIn(response);
 
             expect(spyon).toBeCalledWith('amazon', { expires_at: 0, token: 'access_token' }, {name: 'name' });
-            expect(mockFn).toBeCalledWith('signedIn');
 
             spyon.mockClear();
             spyon2.mockClear();
+            spyon_currentUser.mockClear();
         });
 
         test('directly return if access_token is null', async () => {
@@ -186,6 +195,10 @@ describe('withAmazon test', () => {
                 });
             });
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+
             const Comp = withAmazon(MockComp);
             const wrapper = shallow(<Comp/>);
             const comp = wrapper.instance();
@@ -194,6 +207,7 @@ describe('withAmazon test', () => {
 
             expect(spyon).not.toBeCalled();
             spyon.mockClear();
+            spyon_currentUser.mockClear();
         });
 
         test('directly return if getting userinfo failed', async () => {

--- a/packages/aws-amplify-react/__tests__/Auth/Provider/withFacebook-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/Provider/withFacebook-test.js
@@ -165,6 +165,10 @@ describe('withFacebook test', () => {
             });
             const spyon2 = jest.spyOn(Date.prototype, 'getTime').mockReturnValue(0);
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+
             await comp.federatedSignIn({
                 accessToken: 'accessToken',
                 expiresIn: 0
@@ -174,6 +178,7 @@ describe('withFacebook test', () => {
 
             spyon.mockClear();
             spyon2.mockClear();
+            spyon_currentUser.mockClear();
         });
 
         test('happy case with onStateChange exists', async () => {
@@ -198,6 +203,10 @@ describe('withFacebook test', () => {
             const wrapper = shallow(<Comp/>);
             const comp = wrapper.instance();
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return 'user';
+            });
+
             const spyon = jest.spyOn(Auth, 'federatedSignIn').mockImplementationOnce(() => { 
                 return new Promise((res, rej) => {
                     res('credentials');
@@ -215,10 +224,10 @@ describe('withFacebook test', () => {
             });
 
             expect(spyon).toBeCalledWith('facebook', { token: 'accessToken', expires_at: 0 }, { name: 'username' });
-            expect(mockFn).toBeCalledWith('signedIn');
 
             spyon.mockClear();
             spyon2.mockClear();
+            spyon_currentUser.mockClear();
         });
 
         test('directly return if no accesstoken', async () => {
@@ -248,6 +257,10 @@ describe('withFacebook test', () => {
                 });
             });
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+
             await comp.federatedSignIn({
                 accessToken: null,
             });
@@ -255,6 +268,7 @@ describe('withFacebook test', () => {
             expect(spyon).not.toBeCalled();
 
             spyon.mockClear();
+            spyon_currentUser.mockClear();
         });
     });
 

--- a/packages/aws-amplify-react/__tests__/Auth/Provider/withGoogle-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/Provider/withGoogle-test.js
@@ -161,6 +161,10 @@ describe('withGoogle test', () => {
                     });
                 });
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+
             await comp.federatedSignIn(googleUser);
 
             expect(spyon).toBeCalledWith(
@@ -170,6 +174,7 @@ describe('withGoogle test', () => {
             );
 
             spyon.mockClear();
+            spyon_currentUser.mockClear();
         });
 
         test('happy case with onStateChange exists', async () => {
@@ -215,6 +220,10 @@ describe('withGoogle test', () => {
                     });
                 });
 
+            const spyon_currentUser = jest.spyOn(Auth, 'currentAuthenticatedUser').mockImplementationOnce(() => {
+                return Promise.resolve('user');
+            });
+
             await comp.federatedSignIn(googleUser);
 
             expect(spyon).toBeCalledWith(
@@ -222,9 +231,10 @@ describe('withGoogle test', () => {
                 { expires_at: 0, token: 'id_token' },
                 { email: 'email', name: 'name' }
             );
-            expect(mockFn).toBeCalledWith('signedIn');
+            expect(mockFn).toBeCalledWith('signedIn', 'user');
 
             spyon.mockClear();
+            spyon_currentUser.mockClear();
         });
     });
 

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignIn-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignIn-test.js.snap
@@ -738,6 +738,7 @@ exports[`ConfirmSignIn render test render correctly with Props confirmSignIn 1`]
     }
   >
     <InputRow
+      autoComplete="off"
       autoFocus={true}
       key="code"
       name="code"

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignUp-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignUp-test.js.snap
@@ -986,6 +986,7 @@ exports[`ConfirmSignIn normal case render correctly with Props confirmSignUp 1`]
       }
     />
     <InputRow
+      autoComplete="off"
       autoFocus={true}
       key="code"
       name="code"

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ForgotPassword-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ForgotPassword-test.js.snap
@@ -1982,6 +1982,7 @@ exports[`forgotPassword normal case render correctly with state delivery set 1`]
   <SectionBody>
     <div>
       <InputRow
+        autoComplete="off"
         key="code"
         name="code"
         onChange={[Function]}

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/VerifyContact-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/VerifyContact-test.js.snap
@@ -37,6 +37,7 @@ exports[`VerifyContent test render test render submitView if verifyAttr is set 1
     </MessageRow>
     <div>
       <InputRow
+        autoComplete="off"
         key="code"
         name="code"
         onChange={[Function]}

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-jest": "^21.2.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-airbnb": "^2.4.0",
     "babel-preset-env": "^1.6.1",

--- a/packages/aws-amplify-react/src/Auth/Provider/withAmazon.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withAmazon.jsx
@@ -53,10 +53,10 @@ export default function withAmazon(Comp) {
 
                 Auth.federatedSignIn('amazon', { token: access_token, expires_at }, user)
                     .then(credentials => {
-                        logger.debug('getting credentials');
-                        logger.debug(credentials);
+                        return Auth.currentAuthenticatedUser();
+                    }).then(authUser => {
                         if (onStateChange) {
-                            onStateChange('signedIn');
+                            onStateChange('signedIn', authUser);
                         }
                     });
             });

--- a/packages/aws-amplify-react/src/Auth/Provider/withFacebook.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withFacebook.jsx
@@ -60,7 +60,7 @@ export default function withFacebook(Comp) {
                         if (onStateChange) {
                             onStateChange('signedIn', authUser);
                         }
-                    })
+                    });
             });
         }
 

--- a/packages/aws-amplify-react/src/Auth/Provider/withFacebook.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withFacebook.jsx
@@ -49,16 +49,18 @@ export default function withFacebook(Comp) {
 
             const fb = window.FB;
             fb.api('/me', response => {
-                const user = {
+                let user = {
                     name: response.name
                 }
 
                 Auth.federatedSignIn('facebook', { token: accessToken, expires_at }, user)
                     .then(credentials => {
+                        return Auth.currentAuthenticatedUser();
+                    }).then(authUser => {
                         if (onStateChange) {
-                            onStateChange('signedIn');
+                            onStateChange('signedIn', authUser);
                         }
-                    });
+                    })
             });
         }
 

--- a/packages/aws-amplify-react/src/Auth/Provider/withGoogle.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withGoogle.jsx
@@ -30,24 +30,27 @@ export default function withGoogle(Comp) {
             );
         }
 
-        federatedSignIn(googleUser) {
+        async federatedSignIn(googleUser) {
             const { id_token, expires_at } = googleUser.getAuthResponse();
             const profile = googleUser.getBasicProfile();
-            const user = {
+            let user = {
                 email: profile.getEmail(),
                 name: profile.getName()
             };
 
             const { onStateChange } = this.props;
-            return Auth.federatedSignIn(
+            
+            await Auth.federatedSignIn(
                 'google',
                 { token: id_token, expires_at },
                 user
-            ).then(credentials => {
-                if (onStateChange) {
-                    onStateChange('signedIn');
-                }
-            });
+            );
+
+            user = await Auth.currentAuthenticatedUser();
+
+            if (onStateChange) {
+                onStateChange('signedIn', user);
+            }
         }
 
         componentDidMount() {


### PR DESCRIPTION
*Issue #, if available:*
To pass the user object in `onStateChange` so the `authData` gets defined.
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
