### PR TITLE
Fix typo which is breaking oauth combined with cookie storage

### DIFF
--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -136,7 +136,7 @@ export default class AuthClass {
                     RedirectUriSignIn: oauth.redirectSignIn,
                     RedirectUriSignOut: oauth.redirectSignOut,
                     ResponseType: oauth.responseType,
-                    Storage: this.userPool.Storage
+                    Storage: this.userPool.storage
                 },
                 oauth.options
             );


### PR DESCRIPTION
*Issue #, if available:*
Completing a fix to this issue:
https://github.com/aws/aws-amplify/issues/841
https://github.com/aws/aws-amplify/pull/967

*Description of changes:*
Corrects a typo -- as you can see on line 107 of the updated file, the property name should be lower-cased when referenced on 'this'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
